### PR TITLE
JMP addr typos in the trace annotation for Mega

### DIFF
--- a/2emulation/README.md
+++ b/2emulation/README.md
@@ -999,7 +999,7 @@ FFFD r 02
 0033 r 01
 0033 r 01
 0033 W 02 <-- 33 updated to 2
-0209 r 4C <-- JMP 0702
+0209 r 4C <-- JMP 0207
 020A r 07
 020B r 02
 0207 r E6  <-- INC *$33 
@@ -1027,7 +1027,7 @@ FFFF r 03
 01FB r 21
 01FC r 09
 01FD r 02
-0209 r 4C <-- JMP 0702 ; back in main 
+0209 r 4C <-- JMP 0207 ; back in main 
 020A r 07
 020B r 02
 0207 r E6


### PR DESCRIPTION
Hi!

FIrst of all, very nice writeup on your experiments :)

Looks like I found typos - JMP address in the last trace annotation should be rather 0207 than 0702 ...

Keep up the great work!
